### PR TITLE
extend test system by parameter that is not optimized

### DIFF
--- a/src/util_mixed.jl
+++ b/src/util_mixed.jl
@@ -37,10 +37,8 @@ function setup_tools_mixed(p_indiv::DataFrame;
         [:u0, :p] => DataFrames.ByRow(_extract_paropt) => :paropt)
     mixed = extract_mixed_effects(psets, df.paropt)
     priors_pop = setup_priors_pop(keys(mixed.fixed), keys(mixed.random); inv_case, scenario)
-    u0p = ComponentVector(state = df.u0[1], par = df.p[1])
-    pset_u0p = ODEProblemParSetter(system, u0p)
     _setuptools = (indiv_id, u0, p) -> setup_tools_indiv(indiv_id; inv_case, scenario,
-        system, pset_u0p, u0, p, keys_indiv = mixed_keys.indiv)
+        system, u0, p, keys_indiv = mixed_keys.indiv)
     #_tools = _setuptools(df.indiv_id[1], df.u0[1], df.p[1])
     DataFrames.transform!(df,
         [:indiv_id, :u0, :p] => DataFrames.ByRow(_setuptools) => :tools)
@@ -51,7 +49,7 @@ function setup_tools_mixed(p_indiv::DataFrame;
     effect_pos = MTKHelpers.attach_axis(1:length(sample0), MTKHelpers._get_axis(sample0))
     problemupdater = get_problemupdater(inv_case; scenario)
     #
-    pop_info = (;psets, problemupdater, pset_u0p, priors_pop, sample0, effect_pos)
+    pop_info = (;psets, problemupdater, priors_pop, sample0, effect_pos)
     (; mixed, pop_info, indiv_info = df)
 end
 

--- a/test/test_samplesystem_vec.jl
+++ b/test/test_samplesystem_vec.jl
@@ -11,7 +11,7 @@ using SymbolicIndexingInterface: SymbolicIndexingInterface as SII
 
 @testset "system with symbolic arrays" begin
     st = Symbolics.scalarize(m2.x .=> [1.0, 2.0])
-    p_new = Symbolics.scalarize(m2.p .=> [2.1, 2.2, 2.3])
+    p_new = vcat(Symbolics.scalarize(m2.p .=> [2.1, 2.2, 2.3]), m2.i2 => 5.0)
     prob = ODEProblem(sys, st, (0.0, 10.0), p_new)
     @test SII.getp(sys, :m2₊τ)(prob) == 3.0
     @test SII.getp(sys, :m2₊i)(prob) == 0.1
@@ -25,6 +25,6 @@ using SymbolicIndexingInterface: SymbolicIndexingInterface as SII
     # specify by symbol_op instead of num
     _dict_nums = get_system_symbol_dict(sys)
     st = Symbolics.scalarize(_dict_nums[:m2₊x] .=> [10.1, 10.2])
-    prob = ODEProblem(sys, st, (0.0, 10.0), [_dict_nums[:m2₊τ] => 3.0])
+    prob = ODEProblem(sys, st, (0.0, 10.0), [_dict_nums[:m2₊τ] => 3.0, m2.i2 => 5.0])
     @test prob.u0 == [10.1, 10.2]
 end;

--- a/test/test_sitedata.jl
+++ b/test/test_sitedata.jl
@@ -42,13 +42,11 @@ end;
     popt = CA.ComponentVector(state = (m1₊x1 = 1.0, m1₊x2 = 1.0),
         par = (m1₊τ = 1.0, m1₊p = fill(1.0, 3)))
     indiv = flatten1(popt)[(:m1₊x1, :m1₊x2)]
-    pset_u0p = ODEProblemParSetter(sys, popt)
-    res_prior = setup_tools_indiv(:A; inv_case, scenario, system = sys, pset_u0p,
+    res_prior = setup_tools_indiv(:A; inv_case, scenario, system = sys,
         keys_indiv = keys(indiv))
-    res = setup_tools_indiv(:A; inv_case, scenario, system = sys, pset_u0p,
+    res = setup_tools_indiv(:A; inv_case, scenario, system = sys,
         keys_indiv = keys(indiv), u0 = popt.state, p = popt.par)
     #@test eltype(res.u_map) == eltype(res.p_map) == Int
-    @test axis_paropt(pset_u0p) == CA.getaxes(popt)[1]
     @test get_system(res.problem) == sys
     #
     fixed = CA.ComponentVector{Float64}()

--- a/test/test_sitedata_vec.jl
+++ b/test/test_sitedata_vec.jl
@@ -43,15 +43,18 @@ end;
         par = (sv₊τ = 1.0, sv₊p = fill(1.0, 3)))
     random = flatten1(popt)[(:sv₊x, :sv₊τ)]
     indiv = flatten1(popt)[(:sv₊p,)]
-    pset_u0p = ODEProblemParSetter(sys, popt)
-    res_prior = setup_tools_indiv(:A; inv_case, scenario, system = sys, pset_u0p,
+    @test_throws "i2" setup_tools_indiv(:A; inv_case, scenario, system = sys,
         keys_indiv = keys(indiv))
-    res = setup_tools_indiv(:A; inv_case, scenario, system = sys, pset_u0p,
+    res_prior = setup_tools_indiv(:A; inv_case, scenario, system = sys,
+        keys_indiv = keys(indiv), p_default = CA.ComponentVector(sv₊i2 = 5.0,))
+    @test_throws "sv₊i2" setup_tools_indiv(:A; inv_case, scenario, system = sys,
         keys_indiv = keys(indiv), u0 = popt.state, p = popt.par)
+    res = setup_tools_indiv(:A; inv_case, scenario, system = sys,
+        keys_indiv = keys(indiv), u0 = popt.state, p = popt.par, 
+        p_default = CA.ComponentVector(sv₊i = 4.0, sv₊i2 = 5.0,))        
     #@test eltype(res.u_map) == eltype(res.p_map) == Int
     @test eltype(res.priors_indiv) <: Distribution
     @test keys(res.priors_indiv) == keys(indiv)
-    @test axis_paropt(pset_u0p) == CA.getaxes(popt)[1]
     @test get_system(res.problem) == sys
     #
     fixed = CA.ComponentVector{Float64}()


### PR DESCRIPTION
and has no default - test providing values in addition to priors

remove pset_u0p. It is constructed easily when system is available. And confusing the order was too large.